### PR TITLE
댓글 기능 수정 

### DIFF
--- a/0617/src/components/Landing/ReviewForm.jsx
+++ b/0617/src/components/Landing/ReviewForm.jsx
@@ -3,20 +3,106 @@ import styles from './reviewForm.module.scss';
 import { MdOutlineCameraAlt } from 'react-icons/md';
 import { FaTimes } from 'react-icons/fa';
 import Spinner from '@/components/common/Spinner/index';
+import { useRef, useState } from 'react';
+import supabase from '@/apis/supabaseApi';
 
 const cx = classNames.bind(styles);
 
-function ReviewForm({
-  user,
-  handleInput,
-  handleUploadAndSubmit,
-  textareaRef,
-  previewUrl,
-  handleFileChange,
-  handleCancelSelection,
-  uploadImg,
-}) {
-  console.log(uploadImg);
+function ReviewForm({ user, productId, reviewList, setReviewList }) {
+  const textareaRef = useRef(null);
+  const [file, setFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const [uploadImg, setUploading] = useState(false);
+
+  const handleInput = (event) => {
+    const { value } = event.target;
+    if (value.length <= 3000) {
+      adjustTextareaHeight();
+    }
+  };
+
+  const adjustTextareaHeight = () => {
+    if (textareaRef.current) {
+      const minHeight = 50;
+      textareaRef.current.style.height = 'auto';
+      const scrollHeight = textareaRef.current.scrollHeight;
+      if (scrollHeight >= minHeight) {
+        textareaRef.current.style.height = `${scrollHeight + 4}px`;
+      }
+    }
+  };
+
+  const handleFileChange = (event) => {
+    const selectedFile = event.target.files[0];
+    setFile(selectedFile);
+    setPreviewUrl(URL.createObjectURL(selectedFile));
+  };
+
+  const handleUploadAndSubmit = async () => {
+    try {
+      setUploading(true);
+      let imageUrl = null;
+      if (textareaRef.current.value === '') {
+        alert('내용을 입력해주세요.');
+        setUploading(false);
+        return;
+      }
+
+      if (file) {
+        const fileExt = file.name.split('.').pop();
+        const fileName = `${Date.now()}.${fileExt}`;
+        const filePath = `public/${fileName}`;
+
+        let { error: uploadError } = await supabase.storage
+          .from('images')
+          .upload(filePath, file, {
+            cacheControl: '3600',
+            upsert: false,
+          });
+
+        if (uploadError) {
+          throw uploadError;
+        }
+
+        const publicUrl = supabase.storage
+          .from('images')
+          .getPublicUrl(filePath);
+
+        imageUrl = publicUrl.data.publicUrl;
+        setPreviewUrl(null);
+        setFile(null);
+      }
+
+      const { data, error } = await supabase
+        .from('reviews')
+        .insert([
+          {
+            product_id: productId,
+            username: user.email,
+            review_text: textareaRef.current.value.trim(),
+            review_img: imageUrl,
+          },
+        ])
+        .select();
+      if (error) {
+        return;
+      } else {
+        setReviewList([...reviewList, ...data]);
+        textareaRef.current.value = '';
+      }
+    } catch (error) {
+      console.log(error);
+      alert('Error uploading image and submitting review!');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleCancelSelection = () => {
+    setPreviewUrl(null);
+    setFile(null);
+  };
+
   return (
     <article className={cx('reviewBox')}>
       <div className={cx('reviewHeader')}>

--- a/0617/src/components/Landing/ReviewForm.jsx
+++ b/0617/src/components/Landing/ReviewForm.jsx
@@ -2,6 +2,7 @@ import classNames from 'classnames/bind';
 import styles from './reviewForm.module.scss';
 import { MdOutlineCameraAlt } from 'react-icons/md';
 import { FaTimes } from 'react-icons/fa';
+import Spinner from '@/components/common/Spinner/index';
 
 const cx = classNames.bind(styles);
 
@@ -13,7 +14,9 @@ function ReviewForm({
   previewUrl,
   handleFileChange,
   handleCancelSelection,
+  uploadImg,
 }) {
+  console.log(uploadImg);
   return (
     <article className={cx('reviewBox')}>
       <div className={cx('reviewHeader')}>
@@ -48,10 +51,11 @@ function ReviewForm({
             id='fileInput'
             onChange={handleFileChange}
             className={cx('fileInput')}
+            disabled={uploadImg}
           />
         </div>
         <button onClick={handleUploadAndSubmit} className={cx('submitButton')}>
-          등록
+          {uploadImg ? <Spinner /> : '등록'}
         </button>
       </div>
     </article>

--- a/0617/src/components/Landing/ReviewList.jsx
+++ b/0617/src/components/Landing/ReviewList.jsx
@@ -1,9 +1,44 @@
 import classNames from 'classnames/bind';
 import styles from './reviewList.module.scss';
+import { useEffect } from 'react';
+import supabase from '@/apis/supabaseApi';
 
 const cx = classNames.bind(styles);
 
-function ReviewList({ reviewList }) {
+const fetchReviews = async (productId) => {
+  const { data, error } = await supabase
+    .from('reviews')
+    .select('*')
+    .eq('product_id', productId);
+
+  if (error) {
+    return;
+  } else {
+    console.log(data);
+    return data;
+  }
+};
+
+function ReviewList({ productId, reviewList, setReviewList }) {
+  // const [reviewList, setReviewList] = useState([]);
+  console.log(productId);
+  console.log(reviewList);
+
+  useEffect(() => {
+    const loadReviewList = async () => {
+      try {
+        const data = await fetchReviews(productId);
+        console.log(data);
+        setReviewList(data);
+      } catch (err) {
+        return;
+      }
+    };
+    console.log(reviewList);
+
+    loadReviewList();
+  }, [productId]);
+
   return (
     <div className={cx('reviewListSection')}>
       <p className={cx('reviewCount')}>💬 리뷰 {reviewList.length}</p>

--- a/0617/src/components/Landing/reviewForm.module.scss
+++ b/0617/src/components/Landing/reviewForm.module.scss
@@ -82,7 +82,8 @@
   color: white;
   border: none;
   border-radius: 4px;
-  padding: 10px 20px;
+  min-width: 63px;
+  min-height: 36px;
   cursor: pointer;
 }
 

--- a/0617/src/components/common/Spinner/index.jsx
+++ b/0617/src/components/common/Spinner/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './spinner.module.scss';
+import classNames from 'classnames/bind';
+
+const cx = classNames.bind(styles);
+
+const index = () => (
+  <div className={cx('spinner')}>
+    <div className={cx('double-bounce1')}></div>
+    <div className={cx('double-bounce2')}></div>
+  </div>
+);
+
+export default index;

--- a/0617/src/components/common/Spinner/spinner.module.scss
+++ b/0617/src/components/common/Spinner/spinner.module.scss
@@ -1,0 +1,33 @@
+.spinner {
+  width: 20px;
+  height: 20px;
+  position: relative;
+  margin: auto;
+}
+
+.double-bounce1,
+.double-bounce2 {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: #fff;
+  opacity: 0.6;
+  position: absolute;
+  top: 0;
+  left: 0;
+  animation: sk-bounce 2s infinite ease-in-out;
+}
+
+.double-bounce2 {
+  animation-delay: -1s;
+}
+
+@keyframes sk-bounce {
+  0%,
+  100% {
+    transform: scale(0);
+  }
+  50% {
+    transform: scale(1);
+  }
+}

--- a/0617/src/page/detail/index.jsx
+++ b/0617/src/page/detail/index.jsx
@@ -9,7 +9,7 @@ import styles from './detail.module.scss';
 
 const cx = classNames.bind(styles);
 
-const fetchProductDetail = async (setProductDetail, productId) => {
+const fetchProductDetail = async (productId) => {
   const { data, error } = await supabase
     .from('products')
     .select('*')
@@ -18,11 +18,11 @@ const fetchProductDetail = async (setProductDetail, productId) => {
   if (error) {
     return;
   } else {
-    setProductDetail(data);
+    return data;
   }
 };
 
-const fetchReviews = async (setReviewList, productId) => {
+const fetchReviews = async (productId) => {
   const { data, error } = await supabase
     .from('reviews')
     .select('*')
@@ -31,7 +31,7 @@ const fetchReviews = async (setReviewList, productId) => {
   if (error) {
     return;
   } else {
-    setReviewList(data);
+    return data;
   }
 };
 
@@ -47,8 +47,29 @@ function index() {
   const [uploadImg, setUploading] = useState(false);
 
   useEffect(() => {
-    fetchProductDetail(setProductDetail, productId);
-    fetchReviews(setReviewList, productId);
+    const loadProductDetail = async () => {
+      try {
+        const data = await fetchProductDetail(productId);
+        setProductDetail(data);
+      } catch (err) {
+        return;
+      }
+    };
+
+    loadProductDetail();
+  }, [productId]);
+
+  useEffect(() => {
+    const loadProductDetail = async () => {
+      try {
+        const data = await fetchReviews(productId);
+        setReviewList(data);
+      } catch (err) {
+        return;
+      }
+    };
+
+    loadProductDetail();
   }, [productId]);
 
   const handleInput = (event) => {

--- a/0617/src/page/detail/index.jsx
+++ b/0617/src/page/detail/index.jsx
@@ -22,29 +22,12 @@ const fetchProductDetail = async (productId) => {
   }
 };
 
-const fetchReviews = async (productId) => {
-  const { data, error } = await supabase
-    .from('reviews')
-    .select('*')
-    .eq('product_id', productId);
-
-  if (error) {
-    return;
-  } else {
-    return data;
-  }
-};
-
 function index() {
   const { productId } = useParams();
   const { user } = useAuth();
-  const textareaRef = useRef(null);
 
   const [productDetail, setProductDetail] = useState(null);
   const [reviewList, setReviewList] = useState([]);
-  const [file, setFile] = useState(null);
-  const [previewUrl, setPreviewUrl] = useState(null);
-  const [uploadImg, setUploading] = useState(false);
 
   useEffect(() => {
     const loadProductDetail = async () => {
@@ -58,108 +41,6 @@ function index() {
 
     loadProductDetail();
   }, [productId]);
-
-  useEffect(() => {
-    const loadProductDetail = async () => {
-      try {
-        const data = await fetchReviews(productId);
-        setReviewList(data);
-      } catch (err) {
-        return;
-      }
-    };
-
-    loadProductDetail();
-  }, [productId]);
-
-  const handleInput = (event) => {
-    const { value } = event.target;
-    if (value.length <= 3000) {
-      adjustTextareaHeight();
-    }
-  };
-
-  const adjustTextareaHeight = () => {
-    if (textareaRef.current) {
-      const minHeight = 50;
-      textareaRef.current.style.height = 'auto';
-      const scrollHeight = textareaRef.current.scrollHeight;
-      if (scrollHeight >= minHeight) {
-        textareaRef.current.style.height = `${scrollHeight + 4}px`;
-      }
-    }
-  };
-
-  const handleFileChange = (event) => {
-    const selectedFile = event.target.files[0];
-    setFile(selectedFile);
-    setPreviewUrl(URL.createObjectURL(selectedFile));
-  };
-
-  const handleUploadAndSubmit = async () => {
-    try {
-      setUploading(true);
-      let imageUrl = null;
-      if (textareaRef.current.value === '') {
-        alert('내용을 입력해주세요.');
-        setUploading(false);
-        return;
-      }
-
-      if (file) {
-        const fileExt = file.name.split('.').pop();
-        const fileName = `${Date.now()}.${fileExt}`;
-        const filePath = `public/${fileName}`;
-
-        let { error: uploadError } = await supabase.storage
-          .from('images')
-          .upload(filePath, file, {
-            cacheControl: '3600',
-            upsert: false,
-          });
-
-        if (uploadError) {
-          throw uploadError;
-        }
-
-        const publicUrl = supabase.storage
-          .from('images')
-          .getPublicUrl(filePath);
-
-        imageUrl = publicUrl.data.publicUrl;
-        setPreviewUrl(null);
-        setFile(null);
-      }
-
-      const { data, error } = await supabase
-        .from('reviews')
-        .insert([
-          {
-            product_id: productId,
-            username: user.email,
-            review_text: textareaRef.current.value.trim(),
-            review_img: imageUrl,
-          },
-        ])
-        .select();
-
-      if (error) {
-        return;
-      } else {
-        setReviewList([...reviewList, ...data]);
-        textareaRef.current.value = '';
-      }
-    } catch (error) {
-      alert('Error uploading image and submitting review!');
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handleCancelSelection = () => {
-    setPreviewUrl(null);
-    setFile(null);
-  };
 
   return (
     <>
@@ -178,18 +59,18 @@ function index() {
               </div>
             </article>
           </section>
-          <ReviewList reviewList={reviewList} />
+          <ReviewList
+            productId={productId}
+            reviewList={reviewList}
+            setReviewList={setReviewList}
+          />
           <div className={cx('reviewFormSection')}>
             {user ? (
               <ReviewForm
                 user={user}
-                handleInput={handleInput}
-                handleUploadAndSubmit={handleUploadAndSubmit}
-                textareaRef={textareaRef}
-                previewUrl={previewUrl}
-                handleCancelSelection={handleCancelSelection}
-                handleFileChange={handleFileChange}
-                uploadImg={uploadImg}
+                reviewList={reviewList}
+                setReviewList={setReviewList}
+                productId={productId}
               />
             ) : (
               <div className={cx('loginPrompt')}>

--- a/0617/src/page/detail/index.jsx
+++ b/0617/src/page/detail/index.jsx
@@ -168,6 +168,7 @@ function index() {
                 previewUrl={previewUrl}
                 handleCancelSelection={handleCancelSelection}
                 handleFileChange={handleFileChange}
+                uploadImg={uploadImg}
               />
             ) : (
               <div className={cx('loginPrompt')}>


### PR DESCRIPTION
<br />

## 📝 이슈 상세설명

- [x] uploadImg state는 사용하지 않고 있는데, 왜 선언했나요?

    ➡️ uploadimg state 사용 가능하도록 코드 수정

- [x]  상관은 없지만 다른 페이지 혹은 컴포넌트에서 상품 상세, 리뷰들을 API로 가져오는 코드를 사용할 땐 setProductDetail, setReveiwList 때문에 재사용을 못할 수도 있을 것 같습니다. API를 가져오는 기능 이외에 state도 변경시키기는 두 가지 역할을 하고 있네요

    ➡️ api 함수 재사용 가능하도록 usestate 제거 

- [x] const [reviewList, setReviewList] = useState([]);  state는 여기가 아니라 ReviewList 컴포넌트 안에서 선언해도 되지 않을까요? index.js 파일의 코드에 상품 정보와 리뷰 정보가 함께 있어 코드를 읽기가 불편한 것 같습니다.
- [x] 3번에서 말한 것처럼 이 코드들은 전체 다 ReviewList에 들어가는 게 맞을 것 같습니다.

    ➡️ 🧐 reviewList state를 reviewform 과 reviewList 에서 사용중이라 prop을 상위로 올리는 방법밖에 외에 생각나지 않아서 두 컴포넌트에서 공통으로 사용하는 reviewList 를 제외한 나머지 함수들은 해당 컴포넌트안으로 이동 했습니다






